### PR TITLE
Bug Fix on Products Model.

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -11,7 +11,7 @@ class Product < ActiveRecord::Base
   end
 
   def product_whitelist_labels
-    return I18n::t( :empty ) if self.product_whitelist.empty?
+    return I18n::t( :empty_field ) if self.product_whitelist.empty?
     labels = [ ]
     self.product_whitelist.each do |p|
       labels.push( Product::find( p ).label )
@@ -20,7 +20,7 @@ class Product < ActiveRecord::Base
   end
 
   def platform_whitelist_labels
-    return I18n::t( :empty ) if self.platform_whitelist.empty?
+    return I18n::t( :empty_field ) if self.platform_whitelist.empty?
     labels = [ ]
     self.platform_whitelist.each do |p|
       labels.push( Platform::find( p ).label )

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -10,7 +10,7 @@ pt-BR:
   cancel: Cancelar
   authorize: Autorizar
   back: Voltar
-  empty: (N/A)
+  empty_field: (N/A)
   view: Ver Todos
   password: Senha
   login_in: Efetuando login...


### PR DESCRIPTION
- Fixed the bug that occurred when accessing `products#show' and the
  selected product had empty arrays for the platforms and products
  white-lists. The problem was caused by a mistake in the translation
  file, which had two entries for the`:empty' value.
