### PR TITLE
Form Logic Issue for Product Whitelists.

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -3,8 +3,10 @@ class Product < ActiveRecord::Base
   belongs_to :manufacturer
   #has_one :product_type
 
-  validates :label, presence: true, uniqueness: true
+  validates :label, presence: true
   validates :manufacturer_id, presence: true
+
+  before_validation :remove_empty_elements
 
   def manufacturer
     Manufacturer::find( self.manufacturer_id ).label
@@ -31,6 +33,12 @@ class Product < ActiveRecord::Base
   def short_description
     return self.description if self.description.size <= 100
     self.description[0...100] + '(...)'
+  end
+
+  private
+  def remove_empty_elements
+    self.platform_whitelist.delete( '0' )
+    self.product_whitelist.delete( '0' )
   end
   
 end

--- a/app/views/products/_form.html.haml
+++ b/app/views/products/_form.html.haml
@@ -16,15 +16,15 @@
     Plataformas Compatíveis:
     %br
     - Platform::order( :label ).each do |p|
-      = f.check_box :platform_whitelist, { multiple: true }, p.id, false
+      = f.check_box :platform_whitelist, { multiple: true }, p.id, 0
       = f.label :platform_whitelist, p.label# + " (#{p.version})"
       %br/
     %br/
     Sistemas Compatíveis:
     %br/
     - Product::order( :label ).each do |p|
-      = f.check_box :product_whitelist, { multiple: true }, p.id, false
-      = f.label :product_whitelist, p.label 
+      = f.check_box :product_whitelist, { multiple: true }, p.id, 0
+      = f.label :product_whitelist, p.label
       %br/
     #commands
       = f.submit t( :save )

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -5,8 +5,7 @@
 # property set.  Don't declare `role :all`, it's a meta role.
 
 #role :app, %w{deploy@example.com}
-#role :web, %w{ib@comissionamentos.ddns.net:3001}
-role :web, %w{ib@192.168.1.200}
+role :web, %w{ib@comissionamentos.ddns.net:3001}
 #role :db,  %w{deploy@example.com}
 
 


### PR DESCRIPTION
- A little patch to solve an issue that caused the whitelist properties
  of a `Product` object not to be updated in a very singular case. If
  there was at least a single element in the `product_whitelist` or
  `platform_whitelist` properties, if in an update the HTML form
  check-box elements for these properties were all unchecked, the `params`
  with the POST request would send empty arrays, causing the issue.
  Solved by simply sending `0` (zeroes) instead of `nil` objects for
  unchecked elements, and then wiping these zeroes from the array on a
  `#before_validation` callback on the model.
- There's a little fix for the Capistrano configuration as well.
