### PR TITLE
Single line menu and Img Header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 
 # Ignore precompiled assets.
 /public/assets
+
+# Ignore DB seeds.
+/db/seeds.rb

--- a/app/assets/stylesheets/desktop/main.css.scss
+++ b/app/assets/stylesheets/desktop/main.css.scss
@@ -38,6 +38,18 @@ p, ol, td {
   z-index: 10;
 }
 
+#square {
+  position: relative;
+  top: 0px;
+  left: 0px;
+  z-index: 11;
+  
+  img {
+    width: auto;
+    height: 102px;
+  }
+}
+
 #alert {
   @include title-banner;
   background-color: #D50000; // Vermelho A700 - Google Material Design Pallete
@@ -86,8 +98,8 @@ p, ol, td {
     transition-duration: .2s;
     margin-top: 6px;
     margin-bottom: 0;
-    margin-left: 20px;
-    margin-right: 20px;
+    margin-left: 10px;
+    margin-right: 10px;
     font-weight: bold;
   
   }
@@ -395,8 +407,8 @@ p, ol, td {
   }
 
   #image2 img {
-    width: 50px;
-    height: 50px;
+    width: 35px;
+    height: 35px;
   }
 }
 // END OF FOOTER //
@@ -735,7 +747,7 @@ nav {
     color: #00695C;
     display: block;
     font: bold 13px/20px sans-serif;
-    padding: 0 25px;
+    padding: 0 10px;
     padding-top: 5px;
     text-align: center;
     text-decoration: none;

--- a/app/views/layouts/_menu.html.haml
+++ b/app/views/layouts/_menu.html.haml
@@ -1,21 +1,22 @@
 %nav
   %ul
-    %li
-      = remote_link 'Comissionamentos', commissionings_path
-      %ul
-        %li= remote_link 'Atividades', activities_path
-        %li= remote_link 'Soluções', solutions_path
-    %li
-      = remote_link 'Fabricantes', manufacturers_path
-      %ul
-        %li= remote_link 'Sistemas', products_path
-        %li= remote_link 'Plataformas', platforms_path
-        -#%li= remote_link 'Tipos de Produtos', product_types_path
+    %li= remote_link 'Comissionamentos', commissionings_path
+    
+    %li= remote_link 'Fabricantes', manufacturers_path
+    
+    %li= remote_link 'Produtos', products_path
+    
+    %li= remote_link 'Plataformas', platforms_path
+    
+    -#%li= remote_link 'Tipos de Produtos', product_types_path
+    
     %li= remote_link 'Clientes', clients_path
-    %li
-      = remote_link 'Usuários', users_path
-      %ul
-        -#%li= remote_link users_certifications_path
-        %li= remote_link 'Permissões', roles_path
+    
+    %li= remote_link 'Usuários', users_path
+    
+    -#%li= remote_link 'Certificações', users_path
+    
+    %li= remote_link 'Permissões', roles_path
+    
     %li= link_to t( 'logout' ), logout_path, method: :delete,
           data: { confirm: "This will terminate your login session. Continue?" }

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -15,6 +15,9 @@
     = csrf_meta_tags
 
   %body
+    - if user_signed_in?
+      #square
+        = image_tag 'imgtest.png'
     #title= content_for?( :title ) ? yield( :title ) : 'Potential Ironman'
     - if user_signed_in?
       #hmenu= render 'layouts/menu'


### PR DESCRIPTION
In this commit, the navigation menu is arranged in a single line
and was created space in the header for the logo
- Fixes #15.
