### PR TITLE
Fix for Commissioning POST Bug.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@
 
 # Ignore DB seeds.
 /db/seeds.rb
+
+# Ignore VIM swap files.
+*.swp

--- a/app/controllers/commissionings_controller.rb
+++ b/app/controllers/commissionings_controller.rb
@@ -47,7 +47,6 @@ class CommissioningsController < ApplicationController
   # PATCH/PUT /commissionings/1.json
   def update
     p = commissioning_params
-    p[:commissioners].reject!( &:empty? )
     p[:authorized] = true if params[:commit] == t( :authorize )
 
     respond_to do |format|

--- a/app/models/commissioning.rb
+++ b/app/models/commissioning.rb
@@ -8,6 +8,8 @@ class Commissioning < ActiveRecord::Base
   validates :label, presence: true, uniqueness: true
   validates :client_id, presence: true
 
+  before_validation :remove_empty_elements, if: lambda { self.authorized }
+
   def client_label
     Client::find( self.client_id ).label
   end
@@ -38,6 +40,11 @@ class Commissioning < ActiveRecord::Base
   def short_description
     return self.description if self.description.size <= 100
     self.description[0...100] + '(...)'
+  end
+
+  private
+  def remove_empty_elements
+    self.commissioners.reject!( &:empty? )
   end
   
 end

--- a/app/views/commissionings/_form.html.haml
+++ b/app/views/commissionings/_form.html.haml
@@ -22,7 +22,7 @@
             %td
               = f.check_box :commissioners,
                 { multiple: true,
-                checked: @commissioning.user_ids.include?( u.id ) },
+                checked: @commissioning.commissioners.include?( u.id ) },
                 u.id, ''
               = f.label :commissioners, u.name
     #commands


### PR DESCRIPTION
- Fixes issue #32, which prevented a `Commissioning` object's
  `authorized` attribute to be updated because of a logic error in the
  controller;
- Moved the empty string rejection logic to the Model.
